### PR TITLE
Hide the scroll bar on the right of the electron app #7

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -96,7 +96,17 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
+html {
+  overflow: auto !important;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+html::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
 .app-drawer {
   background-color: #094074 !important;
 }


### PR DESCRIPTION
This will keep the scroll functionality, but not show the scroll bar. This is done of the index.html file as the root app.vue file is using scoped css styles.